### PR TITLE
Disable automatic junk detection on Python >=2.7.1

### DIFF
--- a/diff.py
+++ b/diff.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2.2
+#!/usr/bin/python
 """HTML Diff: http://www.aaronsw.com/2002/diff
 Rough code, badly documented. Send me comments and patches."""
 
@@ -15,7 +15,10 @@ def textDiff(a, b):
 
 	out = []
 	a, b = html2list(a), html2list(b)
-	s = difflib.SequenceMatcher(None, a, b)
+	try: # autojunk can cause malformed HTML, but also speeds up processing.
+		s = difflib.SequenceMatcher(None, a, b, autojunk=False)
+	except TypeError:
+		s = difflib.SequenceMatcher(None, a, b)
 	for e in s.get_opcodes():
 		if e[0] == "replace":
 			# @@ need to do something more complicated here


### PR DESCRIPTION
Starting with python 2.3a, SequenceMatcher performs automated junk
detection on its input. This "feature" can cause unexpected behavior
in some circumstances (see http://bugs.python.org/issue2986). In Python
2.7.1, a flag was added to disable automatic junk detection. This
patch disables junk detection when possible to ensure an accurate diff,
at the expense of speed. Note that there is no way to turn off junk
detection for Python versions between 2.3a and 2.7.
